### PR TITLE
hotfix: solve the challenge of container restarting in prod

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,3 @@ Dockerfile
 .git
 README.md
 .gitignore
-.env

--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+ENVIRONMENT=production
 ATLAS_URI=mongodb+srv://granite:granite4321@cluster0-x0wnn.gcp.mongodb.net/<dbname>?retryWrites=true&w=majority
 JWT_SECRET=Team-granite-microservice
 MONGO_USERNAME=teamgranite

--- a/src/db/mongoose.js
+++ b/src/db/mongoose.js
@@ -3,9 +3,15 @@ const mongoose = require('mongoose');
 const dotenv = require('dotenv');
 
 dotenv.config();
+
+const {
+    ENVIRONMENT,
+    ATLAS_URI,
+    LOCAL_MONGO_DB_URL
+} = process.env;
 const connectToDatabase = () => {
-	
-    mongoose.connect(process.env.LOCAL_MONGO_DB_URL, {
+	const dbUrl = ENVIRONMENT === 'production' ? ATLAS_URI : LOCAL_MONGO_DB_URL;
+    mongoose.connect(dbUrl, {
         useUnifiedTopology: true,
         useNewUrlParser: true,
         useCreateIndex: true,


### PR DESCRIPTION
* Added a new environment variable `ENVIRONMENT` with value *production* or anything else.
* Removed `.env` file from `.dockerignore` file. This would ensure the .env file gets copied into the container environment.
* Modified the `mongoose.js` file to check if `process.env.ENVIRONMENT === production` in which case it uses the `ATLAS_URL` as the database. Else, it uses the `LOCAL_MONGO_DB_URL` 
